### PR TITLE
Added Frei0r blur filter (paving the way for more Frei0r filters)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ var fadeIn = new MLT.Filter.AudioFade({
 ### Create a Frei0r blur filter
 ```js
 var frei0r = new MLT.Filter.Frei0r
-blur.squareblur([
+frei0r.squareblur([
   {
     frame: 0,
     size: 0.05

--- a/README.md
+++ b/README.md
@@ -72,6 +72,22 @@ var fadeIn = new MLT.Filter.AudioFade({
 });
 ```
 
+### Create a Frei0r blur filter
+```js
+var frei0r = new MLT.Filter.Frei0r
+blur.squareblur([
+  {
+    frame: 0,
+    size: 0.05
+  },
+  {
+    frame: 22,
+    size: 0
+  }
+]);
+
+```
+
 ### Add producers to a playlist with filters
 ```js
 var playlist = new MLT.Playlist;

--- a/lib/mlt/filter.js
+++ b/lib/mlt/filter.js
@@ -82,6 +82,28 @@ AudioFade.prototype.id = function () {
   return this._attribs.id
 };
 
+var Frei0r = function (params) {
+  this._attribs = {
+    id: uuid()
+  }
+}
+Frei0r.prototype = _.extend(Frei0r.prototype, require('../interfaces/properties.js'), require('../interfaces/xml'))
+Frei0r.prototype._node = 'filter'
+Frei0r.prototype.squareblur = function (kernelSizes) {
+  this._attribs.mlt_service = 'frei0r.squareblur'
+  this._inner = {}
+  var kernelSizesString = ''
+  _.each(kernelSizes, function (kernel) {
+    kernelSizesString += kernel.frame + '=' + kernel.size + ';'
+  });
+  kernelSizesString = kernelSizesString.replace(/;$/, '')
+  this._props("Kernel size", kernelSizesString)
+  return this
+};
+Frei0r.prototype.id = function () {
+  return this._attribs.id
+}
+
 var Watermark = function (params) {
   this._attribs = {
     mlt_service: 'watermark',
@@ -124,6 +146,7 @@ WebVFX.prototype.id = function () {
 module.exports = {
   Affine: Affine,
   AudioFade: AudioFade,
+  Frei0r: Frei0r,
   Watermark: Watermark,
   WebVFX: WebVFX
 }


### PR DESCRIPTION
This filter is documented <a href="http://www.mltframework.org/bin/view/MLT/FilterFrei0r-squareblur">here</a>. Frei0r filters use numbers for the parameter names, so parameters must be added as properties instead of attributes. I would like to continue adding more filters (including Frei0r filters) in this same fashion.